### PR TITLE
Forced cache invalidation renamed & explanation added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,28 +34,34 @@ On OS X the node-webkit executable is called `node-webkit` and on linux and Wind
 
 The result of each request will be the requested image.
 
-```
-# Take a screenshot
-GET /?url=www.google.com
-# Return a 1024x600 PNG screenshot of the www.google.com homepage
+##### Take a screenshot 
+`GET /?url=www.google.com`
 
-# Take a screenshot with transparency
-GET /?url=www.google.com&transparent=true
-# Return a 1024x600 PNG screenshot of the www.google.com homepage
+Returns a 1024x600 PNG screenshot of the www.google.com homepage
+##### Take a screenshot with transparency
+`GET /?url=www.google.com&transparent=true`
 
-# Take a screenshot of the whole page
-GET /?url=www.google.com&page=true
-# Return a screenshot of the whole www.google.com homepage
+Returns a 1024x600 PNG screenshot of the www.google.com homepage
 
-# Custom viewport size
-GET /?url=www.google.com&width=800&height=600
-# Return a 800x600 PNG screenshot of the www.google.com homepage
+##### Take a screenshot of the whole page
+`GET /?url=www.google.com&page=true`
 
-# Screenshot delay
-GET /?url=www.google.com&delay=1000
-# Return a 1024x600 PNG screenshot of the www.google.com homepage
-# 1 second after it's loaded
-```
+Returns a screenshot of the whole www.google.com homepage
+
+##### Custom viewport size
+`GET /?url=www.google.com&width=800&height=600`
+
+Returns a 800x600 PNG screenshot of the www.google.com homepage
+
+##### Screenshot delay
+`GET /?url=www.google.com&delay=1000`
+
+Returns a 1024x600 PNG screenshot of the www.google.com homepage 1 second after it's loaded
+
+##### Force cache reload
+`GET /?url=www.google.com&forceReload=1`
+
+Deletes current version in cache and returns a (new) 1024x600 PNG screenshot of the www.google.com homepage, which will be cached again
 
 
 ### Ajax API

--- a/nodeshot-server/lib/buildOptions.js
+++ b/nodeshot-server/lib/buildOptions.js
@@ -3,7 +3,7 @@
  * Build an options object from the request query.
  */
 var numOptions  = ['width', 'height', 'delay'],
-    boolOptions = ['page', 'scrollbar', 'transparent', 'force'],
+    boolOptions = ['page', 'scrollbar', 'transparent', 'forceReload'],
     strOptions  = ['format', 'callback'];
 
 var buildOptions = function(query, defaults){

--- a/nodeshot-server/routes/index.js
+++ b/nodeshot-server/routes/index.js
@@ -38,8 +38,8 @@ module.exports = function (app, config, pendingJobs, cacheService){
         winston.info('Request "%s", cacheId: "%s"', url, imageId, optionStr);
 
 
-        // &force will invalidate the cache
-        if ( options.force ){
+        // append `&forceReload=1` to query to invalidate the cache and get a new image
+        if ( options.forceReload ){
           winston.info('Remove "%s" from cache', imageId);
           cacheService.removeFile(imageId);
         }


### PR DESCRIPTION
I'd suggest to rename the `force` parameter to `forceReload` which is more obvious in terms of what it will do. I also fixed the comment (`&force` doesn't work, only `&force=1`) and added something to the README (which I restyled for better readability & linking).
